### PR TITLE
Convert ImmutableArray to array for yaml conversion

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -52,6 +52,7 @@ class DeliveryHelper
 
       hash.each do |attr, value|
         attr = attr.to_sym if symbol?(attr)
+        value = value.to_a if value.is_a?(Chef::Node::ImmutableArray)
         parameters.merge!(attr => value)
       end
 


### PR DESCRIPTION
The cookbook lays down the following gemrc file:
```
---
:benchmark: false
:verbose: true
:update_sources: true
gem: "--no-rdoc --no-ri"
install: "--no-user-install"
:sources: !ruby/array:Chef::Node::ImmutableArray
- http://rubygems.org/
- http://gems.github.com/
:backtrace: true
:bulk_threshold: 1000
```
This breaks chef-client runs because that is not a valid gemrc.

This is happening because arrays and hashes that are on the node object are cast to Immutable objects.  We need to explicitly convert this back to an array to let to_yaml handle it appropriately.