### PR TITLE
Enable custom chef-client config for delivery-cmd

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -103,6 +103,8 @@ delivery_cmd = File.join(node['delivery_build']['bin'], 'delivery-cmd')
 default['push_jobs']['whitelist'] = { 'chef-client'         => 'chef-client',
                                       /^delivery-cmd (.+)$/ => "#{delivery_cmd} '\\1'" }
 
+# What chef config would you like delivery_build to use?
+default['delivery_build']['chef_client_conf'] = platform_family == 'windows' ? 'C:/chef/client.rb' : '/etc/chef/client.rb'
 # Gemrc variables
 #
 # To customize the `~/.gemrc` file you have to modify the following variables,

--- a/templates/default/delivery-cmd.erb
+++ b/templates/default/delivery-cmd.erb
@@ -98,8 +98,9 @@ Raven.capture do
 
 workspace_root = "<%= node['delivery_build']['root'] %>"
 workspace_bin = "<%= node['delivery_build']['bin'] %>"
+chef_client_config = "<% node['delivery_build']['chef_client_conf'] %>"
 
-Chef::Config.from_file(Chef::Config.platform_specific_path("/etc/chef/client.rb"))
+Chef::Config.from_file(Chef::Config.platform_specific_path(chef_client_config))
 client = Chef::Client.new
 client.run_ohai
 client.node_name


### PR DESCRIPTION
We are having issues using this template since it hard codes the Chef Config path to /etc/chef/client.rb. I am just trying to provide a mechanism to enable us to easily customise this. Let me know if you have any other ideas :).
