### PR TITLE
Bump version `0.4.25`

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'apache2'
 description 'Sets up a delivery build node'
-version '0.4.24'
+version '0.4.25'
 
 depends 'git'
 depends 'build-essential'


### PR DESCRIPTION
This was overlooked in: https://github.com/chef-cookbooks/delivery_build/pull/8